### PR TITLE
Fixed FULL_LAZY to pick proper chain-of-states in rubah.runtime.states.States

### DIFF
--- a/src/main/java/rubah/bytecode/transformers/AddTraverseMethod.java
+++ b/src/main/java/rubah/bytecode/transformers/AddTraverseMethod.java
@@ -20,6 +20,7 @@
  *******************************************************************************/
 package rubah.bytecode.transformers;
 
+import java.lang.ThreadLocal;
 import java.lang.ref.Reference;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -69,7 +70,6 @@ public class AddTraverseMethod extends RubahTransformer {
 		// Throwable's backtrace is something handled by native code, don't touch
 		Throwable.class.getName(),
 		Rubah.class.getPackage().getName() + ".",
-		ThreadLocal.class.getName(),
 		Object.class.getPackage().getName(),
 		"sun.nio.ch.SocketChannelImpl",
 		"sun.nio.ch.SocketAdaptor",
@@ -78,11 +78,14 @@ public class AddTraverseMethod extends RubahTransformer {
 
 	public static boolean isAllowed(String fqn) {
 
-		if (fqn.startsWith(Object.class.getName()) || fqn.startsWith(Class.class.getName()) || fqn.startsWith(Reference.class.getPackage().getName()))
+		if (fqn.startsWith(Object.class.getName())
+			|| fqn.startsWith(Class.class.getName())
+			|| fqn.startsWith(Reference.class.getPackage().getName())
+			|| fqn.startsWith(ThreadLocal.class.getName()))
 			return true;
 
-		for (String allowedPak : blackListedPackages) {
-			if (fqn.startsWith(allowedPak)) {
+		for (String disallowedPak : blackListedPackages) {
+			if (fqn.startsWith(disallowedPak)) {
 				return false;
 			}
 		}

--- a/src/main/java/rubah/runtime/state/strategy/FullyLazyMonolithic.java
+++ b/src/main/java/rubah/runtime/state/strategy/FullyLazyMonolithic.java
@@ -407,8 +407,17 @@ public class FullyLazyMonolithic implements MigrationStrategy {
 				AtomicReference ref = (AtomicReference) obj;
 
 				ret = new AtomicReference(this.migrate(ref.get()));
-			}
-			else {
+			} else if (obj.getClass().getName().startsWith(ThreadLocal.class.getName())) {
+				// Migrate java.lang.ThreadLocal$ThreadLocalMap$Entry (which is a subclass of WeakReference)
+
+				// ...$Entry is a key-value-tuple that uses a WeakReference to its key.
+				// The key always points to a ThreadLocal which we assume never to be updated itself,
+				// Therefore, we traverse only the "value" field of Entry and do not rebuilt the WeakReference
+				for (long offset : info.fieldOffsets)
+					this.traverse(ret, offset, ret, offset);
+			} else {
+                                // FIXME: The following cannot properly migrate subclassed references
+                            
 				// TODO find a more general way to migrated references
 				// Taking a chance here...
 				// Follow reference here
@@ -534,6 +543,23 @@ public class FullyLazyMonolithic implements MigrationStrategy {
 				ret.migrateAction = MigrateAction.MIGRATE_CLASS;
 				ret.mappingAction = MappingAction.MAP;
 				ret.traverseAction = TraverseAction.MIGRATE;
+			} else if (Reference.class.isAssignableFrom(c) && c.getName().startsWith(ThreadLocal.class.getName())) {
+				// Migrate java.lang.ThreadLocal$ThreadLocalMap$Entry (which is a subclass of WeakReference)
+
+				// Migrate reference as regular
+				ret.migrateAction = MigrateAction.MIGRATE_REFERENCE;
+				ret.traverseAction = TraverseAction.MIGRATE;
+				ret.proxyClass = Class.forName(ProxyGenerator.generateProxyName(c.getName()), false, Rubah.getLoader());
+				ret.forwardFieldOffset = -1;
+				ret.mappingAction = MappingAction.MAP;
+                 
+				// Addidionally collect fieldOffsets to later on migrate the "value" field               
+				LinkedList<Long> offsets = UnsafeUtils.getInstance().getOffsets(c).getOffsets();
+				ret.fieldOffsets = new long[offsets.size()];
+				int i = 0;
+				for (Long offset : offsets) {
+					ret.fieldOffsets[i++] = offset;
+				}
 			} else if (Reference.class.isAssignableFrom(c) || AtomicReference.class.isAssignableFrom(c)) {
 				ret.migrateAction = MigrateAction.MIGRATE_REFERENCE;
 				ret.traverseAction = TraverseAction.MIGRATE;

--- a/src/main/java/rubah/tools/updater/ParsingArguments.java
+++ b/src/main/java/rubah/tools/updater/ParsingArguments.java
@@ -171,6 +171,7 @@ public class ParsingArguments extends Filter {
 					break;
 				case FULL_LAZY:
 					migrationStrategy = new FullyLazyMonolithic();
+					state.setLazy(true);
 					break;
 				case EAGER_LAZY:
 					migrationStrategy = new EagerLazy(mappingStrategy, this.nThreads);


### PR DESCRIPTION
Dear Mr. Pina,

we have noticed in the "systematic-testing" branch: rubah.runtime.states.States constructs the eager states for FULL_LAZY. We have added setLazy(true) to FULL_LAZY in rubah.tools.updater.ParsingArguments to fix this.

Greetings,
Alex Neumann
